### PR TITLE
Add bypassing failAfter so you can retry forever

### DIFF
--- a/src/connectionFsm.js
+++ b/src/connectionFsm.js
@@ -45,7 +45,7 @@ const Connection = function (options, connectionFn, channelFn) {
     connected: false,
     consecutiveFailures: 0,
     connectTimeout: undefined,
-    failAfter: (options.failAfter || 60) * 1000,
+    failAfter: options.failAfter === 0 ? 0 : ((options.failAfter || 60) * 1000),
 
     initialize: function () {
       options.name = this.name;
@@ -170,7 +170,7 @@ const Connection = function (options, connectionFn, channelFn) {
     },
 
     setConnectionTimeout: function () {
-      if (!this.connectionTimeout) {
+      if (!this.connectionTimeout && this.failAfter !== 0) {
         this.connectionTimeout = setTimeout(() => {
           this.transition('unreachable');
         }, this.failAfter);


### PR DESCRIPTION
Just `retryLimit = 0` is not enough for endless retry. When failAfter is set to 0 then it is truly an endless retry. Need to inspect the topology sections as well to ensure topology is rebuilt after a LOOONG disconnect and then a reconnect.